### PR TITLE
Bugfix/correct container image

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -2,10 +2,10 @@ services:
   web:
     build: .
     ports:
-      - "80:5000"
+      - "5000:5000"
   printer:
-      image: "pklaus/brother_ql_web"
-      ports:
-        - "8013:8013"
-      devices:
-        - '/dev/usb/lp0:/dev/usb/lp0'
+    image: "makefoo/brother_ql_web:latest"
+    ports:
+      - "8013:8013"
+    devices:
+      - '/dev/usb/lp0:/dev/usb/lp0'


### PR DESCRIPTION
the legacy brother_ql_web docker image does not work as it does not provide the correct api endpoints for qr code.
This pull request uses the freshly-built brother_ql_web docker image from kalauerclub/brother_ql_web in the compose file